### PR TITLE
docs(node/nomination/staking): fix broken links

### DIFF
--- a/docs/node_setup.md
+++ b/docs/node_setup.md
@@ -48,7 +48,7 @@ $ ntpq -p
 ## 02 Adjust your firewall settings
 Port `30333` is used for peer-to-peer connections with other nodes. If you are running the node as a validator, we recommend that you set up a firewall and configure to expose only this port for remote connections.
 
-If you are *not* running the node as a validator, you can also consider exposing `9944` (for RPC websocket connections with external apps) and `9933` (for HTTP requests to your node). You can use port `9944` to connect to your node with [Polkadot/apps](polkadotjs_apps_local).
+If you are *not* running the node as a validator, you can also consider exposing `9944` (for RPC websocket connections with external apps) and `9933` (for HTTP requests to your node). You can use port `9944` to connect to your node with [Polkadot/apps](/polkadotjs_apps_local).
 
 ## 03 Download or build a binary
 You can download a binary of our latest release on [github](https://github.com/galacticcouncil/HydraDX-node/releases).

--- a/docs/start_nominating.md
+++ b/docs/start_nominating.md
@@ -17,7 +17,7 @@ Nominating is a more accessible form of participation in the staking process, ho
 
 ## 00 Staking UI
 
-To access the staking interface, you first need to open the Polkadot/apps, connect it to one of the [public HydraDX RPC nodes](polkadotjs_apps_public) and make sure that you can see your account [balance](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-01.snakenet.hydradx.io#/accounts)
+To access the staking interface, you first need to open the Polkadot/apps, connect it to one of the [public HydraDX RPC nodes](/polkadotjs_apps_public) and make sure that you can see your account [balance](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-01.snakenet.hydradx.io#/accounts)
 
 :::note
 

--- a/docs/start_validating.md
+++ b/docs/start_validating.md
@@ -23,7 +23,7 @@ Are you still in possession of xHDX tokens that you bought during the Balancer L
 
 :::
 
-To bond HDX, open Polkadot/apps, and connect to one of the [public HydraDX RPC nodes](polkadotjs_apps_public). Make sure that you can see your account [balance](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-01.snakenet.hydradx.io#/accounts).
+To bond HDX, open Polkadot/apps, and connect to one of the [public HydraDX RPC nodes](/polkadotjs_apps_public). Make sure that you can see your account [balance](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-01.snakenet.hydradx.io#/accounts).
 
 :::warning
 


### PR DESCRIPTION
there were some more broken links.
internal links should always start with a slash.
otherwise it is considered relative to the current URL.