### PR TITLE
Remove CW from council elections guide

### DIFF
--- a/docs/participate_in_council_elections.md
+++ b/docs/participate_in_council_elections.md
@@ -5,41 +5,9 @@ title: Participate in Council Elections
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-This article provides step-by-step guidance on how to participate in Council elections - voting for Council members and becoming a Council candidate. There are two alternative tools which you can use for this purpose - [Commonwealth.im](#cw) or [Polkadot/apps](#polkajs).
+This article provides step-by-step guidance on how to participate in Council elections - voting for Council members and becoming a Council candidate.
 
 If you are interested in how the election mechanism works, please refer to [this post](/democracy_council#elections).
-
-:::caution
-The HydraDX democracy module will be launched on or after **15 September 2021**. Please do not attempt any of the shown actions before that date.
-:::
-
-## Using Commonwealth.im {#cw}
-
-### Vote in Council member elections {#cw-vote}
-You can see the current Council members as well as the runners-up in the [Councillors tab](https://commonwealth.im/hydradx/council) on the HydraDX Commonwealth page.
-
-To bring out your vote for Council members, click on *Vote*.
-
-<div style={{textAlign: 'center'}}>
-  <img src={useBaseUrl('/participate_in_council_elections/cw-vote.jpg')} />
-</div>
-
-Enter the amount of tokens you are willing to lock in support of your candidates.
-
-After that, select your preferred candidates by clicking on their names. Remeber to select multiple candidates - this will help the algorithm select the optimal distribution of candidates to the Council.
-
-To bring out your vote, click on *Submit vote* and sign the transaction.
-
-:::note
-Locked tokens cannot be transferred, however they can still be used for staking and voting in referenda. Your tokens will remain locked and used for subsequent elections until you have decided to unlock them.
-:::
-
-### Apply as a Council candidate {#cw-become_candidate}
-You can submit your application for Council membership by navigating to the [Councillors tab](https://commonwealth.im/hydradx/council) on the HydraDX Commonwealth page.
-
-Click on *Run for council* which will bring you to a page showing the minimum deposit required for membership.
-
-To submit your candidacy, click on *Sign and send transaction* and sign using your wallet.
 
 ## Using Polkadot/apps {#polkajs}
 ### Vote in Council member elections {#polkajs-vote}

--- a/i18n/cn/docusaurus-plugin-content-docs/current/participate_in_council_elections.md
+++ b/i18n/cn/docusaurus-plugin-content-docs/current/participate_in_council_elections.md
@@ -5,41 +5,13 @@ title: 参与议会选举
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-本文提供了关于如何参与议会选举的分步指导： 为议会成员投票和成为议会候选人。 为此，您可以选择使用两种工具： [Commonwealth.im](#cw) 或 [Polkadot/apps](#polkajs)。 
+本文提供了关于如何参与议会选举的分步指导： 为议会成员投票和成为议会候选人。
 
 如果您对选举如何进行感兴趣，请阅读 [此文章](/democracy_council#elections)。
 
 :::caution
 HydraDX民主选举将在 **2021 年 9 月 15 号** 后上线，请勿在此日期前尝试任何显示的操作。
 :::
-
-## 使用 Commonwealth.im {#cw}
-
-### 在议会成员选举中投票 {#cw-vote}
-你可以在 HydraDX Commonwealth 的 [Councillors tab](https://commonwealth.im/hydradx/council)（议员选项卡） 中看到议会的成员及候选人。
-
-点击 *Vote*（投票）进入选举菜单。
-
-<div style={{textAlign: 'center'}}>
-  <img src={useBaseUrl('/participate_in_council_elections/cw-vote.jpg')} />
-</div>
-
-输入您愿意锁定以支持候选人的令牌数量。
-
-之后，通过单击他们的名字来选择您喜欢的候选人。请记住可选择多个候选人，这将有助于算法选择最佳候选人分配给议会。
-
-点击 *Submit Vote*（提交投票）并签名使投票生效。
-
-:::note
-锁定的令牌不可转账，但仍可用于质押和公投投票。直到你手动解锁令牌之前，您的令牌将被锁定并用于下次的选举。
-:::
-
-### 申请成为议会侯选人 {#cw-become_candidate}
-您可以通过导航到 HydraDX Commonwealth 页面上的 [Councillors tab](https://commonwealth.im/hydradx/council) （议员选项卡）来提交议会成员资格申请。
-
-点击 *Run for Council*（竞选议会），将带您进入一个页面，显示会员所需的最低存款。
-
-要提交您的候选资格，请单击 *Sign and send transaction*（签名并发送交易）并使用您的钱包签名。
 
 ## 使用 Polkadot/apps {#polkajs}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/participate_in_council_elections.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/participate_in_council_elections.md
@@ -5,42 +5,13 @@ title: Teilnahme an Ratswahlen
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Dieser Artikel enthält eine Schritt-für-Schritt-Anleitung zur Teilnahme an Ratswahlen - für die Wahl von Ratsmitgliedern und für die Aufnahme als Ratskandidat. Es gibt zwei alternative Tools, die Sie zu diesem Zweck verwenden können - [Commonwealth.im](#cw) or [Polkadot/apps](#polkajs).
+Dieser Artikel enthält eine Schritt-für-Schritt-Anleitung zur Teilnahme an Ratswahlen - für die Wahl von Ratsmitgliedern und für die Aufnahme als Ratskandidat.
 
 Wenn Sie daran interessiert sind, wie der Wahlmechanismus funktioniert, lesen Sie bitte [diesen Beitrag](/democracy_council#elections).
 
 :::caution
 Das HydraDX-Demokratiemodul wird am oder nach dem **15. September 2021** eingeführt. Bitte versuchen Sie vor diesem Datum keine der angezeigten Aktionen.
 :::
-
-## Verwendung von Commonwealth.im {#cw}
-
-### Abstimmung bei den Wahlen zu den Ratsmitgliedern  {#cw-vote}
-Sie können die aktuellen Ratsmitglieder sowie die Zweitplatzierten in der Registerkarte [Ratsmitglieder](https://commonwealth.im/hydradx/council) auf der HydraDX Commonwealth-Seite sehen.
-
-Um Ihre Stimme für die Ratsmitglieder herauszubringen, klicken Sie auf *Vote*.
-
-<div style={{textAlign: 'center'}}>
-  <img src={useBaseUrl('/participate_in_council_elections/cw-vote.jpg')} />
-</div>
-
-Geben Sie die Anzahl der Token ein, die Sie zur Unterstützung Ihrer Kandidaten sperren möchten.
-
-Wählen Sie anschließend Ihre Wunschkandidaten aus, indem Sie auf deren Namen klicken. Denken Sie daran, mehrere Kandidaten auszuwählen - dies hilft dem Algorithmus, die optimale Verteilung der Kandidaten an den Rat auszuwählen.
-
-
-Um Ihre Stimme zu veröffentlichen, klicken Sie auf *Submit vote* und unterschreiben Sie die Transaktion.
-
-:::note
-Gesperrte Token können nicht übertragen werden, sie können jedoch weiterhin zum Abstecken und zur Abstimmung in Volksabstimmungen verwendet werden. Ihre Token bleiben erhalten und werden für nachfolgende Wahlen verwendet, bis Sie sich entschieden haben, sie freizuschalten.
-:::
-
-### Bewerben Sie sich als Ratskandidat {#cw-become_candidate}
-Sie können Ihren Antrag auf Mitgliedschaft im Rat einreichen, indem Sie auf der HydraDX Commonwealth-Seite zur Registerkarte [Ratsmitglieder](https://commonwealth.im/hydradx/council) navigieren.
-
-Klicken Sie auf *Run for Council*, um zu einer Seite mit der für die Mitgliedschaft erforderlichen Mindesteinzahlung zu gelangen.
-
-Um Ihre Kandidatur einzureichen, klicken Sie auf *Sign and send transaction* und unterschreiben Sie mit Ihrem Wallet.
 
 ## Verwundung von Polkadot/apps {#polkajs}
 ### Abstimmung bei den Wahlen zu den Ratsmitgliedern  {#polkajs-vote}

--- a/i18n/es/docusaurus-plugin-content-docs/current/participate_in_council_elections.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/participate_in_council_elections.md
@@ -5,43 +5,13 @@ title: Participar en las elecciones del consejo
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Este artículo proporciona una guía paso a paso sobre cómo participar en las elecciones del Consejo: votar por los miembros del Consejo y convertirse en candidato al Consejo. Hay dos herramientas alternativas que puede utilizar para este propósito: [Commonwealth.im](#cw) o [Polkadot/apps](#polkajs).
+Este artículo proporciona una guía paso a paso sobre cómo participar en las elecciones del Consejo: votar por los miembros del Consejo y convertirse en candidato al Consejo.
 
 Si está interesado en cómo funciona el mecanismo de elección, consulte [esta publicación](/democracy_council#elections).
 
 :::caution
 El módulo de democracia HydraDX se lanzará a partir del **15 de septiembre de 2021**. No intente ninguna de las acciones mostradas antes de esa fecha.
 :::
-
-## Usando Commonwealth.im {#cw}
-
-### Votar en la elección de miembros del Consejo {#cw-vote}
-
-Puede ver los miembros actuales del Consejo, así como los runners-up en la [Councillors tab](https://commonwealth.im/hydradx/council en la página de HydraDX Commonwealth.
-
-Para mostrar su voto por los miembros del Consejo, haga clic en * Vote*.
-
-<div style={{textAlign: 'center'}}>
-  <img src={useBaseUrl('/participate_in_council_elections/cw-vote.jpg')} />
-</div>
-
-Ingrese la cantidad de tokens que está dispuesto a bloquear para apoyar a sus candidatos.
-
-Después de eso, seleccione sus candidatos preferidos haciendo clic en sus nombres. Recuerde seleccionar varios candidatos: esto ayudará al algoritmo a seleccionar la distribución óptima de candidatos al Consejo.
-
-Para mostrar su voto, haga clic en *Submit vote* y firme la transacción.
-
-:::note
-Los tokens bloqueados no se pueden transferir, sin embargo, aún se pueden usar para staking y votar en referendos. Tus tokens seguirán siendo afortunados y se usarán para elecciones posteriores hasta que decidas desbloquearlos.
-:::
-
-### Aplicar a canditato para el Consejo {#cw-become_candidate}
-
-Puede enviar su solicitud para ser miembro del Consejo navegando a la [Councillors tab](https://commonwealth.im/hydradx/council) en la página HydraDX Commonwealth.
-
-Haga clic en * Run for Council* que lo llevará a una página que muestra el depósito mínimo requerido para ser miembro.
-
-Para enviar su candidatura, haga clic en *Sign and send transaction* y firmar con su billetera.
 
 ## Usando Polkadot/apps {#polkajs}
 ### Votar en las elecciones de miembros del Consejo {#polkajs-vote}


### PR DESCRIPTION
We need to remove the CW guide because it doesn't work

Can't run for Council:
<img width="1335" alt="Screenshot 2021-09-17 at 10 40 23" src="https://user-images.githubusercontent.com/2530251/133760739-ee53fee4-3483-4cb6-8745-8b8c0601fbc4.png">

Also can't vote (no list of candidates displayed)