### PR TITLE
Fix stale dev docs, add EVM integration page

### DIFF
--- a/docs/06_devs/01_intro.md
+++ b/docs/06_devs/01_intro.md
@@ -7,21 +7,20 @@ The purpose of the `Build` section of the Hydration documentation is to share te
 
 All technical contributions which are aligned with the goals of Hydration are eligible for generous rewards which are paid out as Treasury tips in HDX. You can find more information about our reward scheme under the following links:
 
-* [New Deal reward scheme announcement](https://hydradx.substack.com/p/incentivized-testnet-reward-scheme)
 * [Example tasks which brings rewards](../community/spending_fw)
 * [How to claim Treasury tips](../community/tip_request)
 
 
 ## How to Start
 
-Hydration is powered by Substrate which is a cutting-edge blockchain framework built on Rust. Knowledge of Rust is therefore an important prerequisite for chain development. If you want to learn Rust, a good place to start is the ["Rust Book"](https://doc.rust-lang.org/stable/book/).
+Hydration is powered by Substrate (via [Polkadot SDK](https://docs.polkadot.com/)) which is a cutting-edge blockchain framework built on Rust. Knowledge of Rust is therefore an important prerequisite for chain development. If you want to learn Rust, a good place to start is the ["Rust Book"](https://doc.rust-lang.org/stable/book/).
 
-A further requirement is basic knowledge of the Substrate framework. If you want to get up to speed quickly, we highly recommend you to subscribe to the [Acala Runtime Developer Academy](https://www.industryconnect.org/substrate-runtime-developer-academy/).
+A further requirement is basic knowledge of the Substrate framework. If you want to get up to speed quickly, the [Polkadot SDK documentation](https://docs.polkadot.com/) is the current, actively maintained resource for this.
 
 
 ## How to Continue
 
 Check out the docs under `Build`. Ask questions on Discord. Fork us. Open a PR with your contribution.
 
-https://github.com/galacticcouncil/HydraDX-node  
+https://github.com/galacticcouncil/hydration-node  
 https://github.com/galacticcouncil/Basilisk-node

--- a/docs/06_devs/02_build_dev_chain.md
+++ b/docs/06_devs/02_build_dev_chain.md
@@ -11,7 +11,7 @@ This section runs you through the process of setting up a local Hydration chain 
 
 To prepare a local Hydration chain instance for development, your machine needs to cover all dependencies for running a Substrate chain. You will need to install a Rust developer environment and make sure that it is configured properly for compiling Substrate runtime code to the WebAssembly (Wasm) target.
 
-You can install and configure all dependencies manually following the [Substrate guide](https://substrate.dev/docs/en/knowledgebase/getting-started), or you could let this script do all the work for you:
+You can install and configure all dependencies manually following the [Polkadot SDK documentation](https://docs.polkadot.com/), or you could let this script do all the work for you:
 
 ```bash
 $ curl https://getsubstrate.io -sSf | bash -s -- --fast
@@ -23,8 +23,8 @@ $ source ~/.cargo/env
 Build the Wasm and native execution environments:
 
 ```bash
-# Fetch source of the latest stable release
-$ git clone https://github.com/galacticcouncil/hydration-node -b stable
+# Fetch source of the current mainnet branch
+$ git clone https://github.com/galacticcouncil/hydration-node -b master
 
 # Build the binary
 $ cd hydration-node/

--- a/docs/06_devs/03_remote_swaps.md
+++ b/docs/06_devs/03_remote_swaps.md
@@ -22,5 +22,5 @@ The extrinsic would be in this example constructed as a _polkadotXcm.send_ call 
 </div>
 
 ## Learn more
-To know more about remote swaps, you can head over to our github repository where you can find [integration tests](https://github.com/galacticcouncil/HydraDX-node/blob/769c33d63d24356791c2f0e276350ebdc2914005/integration-tests/src/exchange_asset.rs#L341) covering more advanced scenarios.
+To know more about remote swaps, you can head over to our github repository where you can find [integration tests](https://github.com/galacticcouncil/hydration-node/blob/769c33d63d24356791c2f0e276350ebdc2914005/integration-tests/src/exchange_asset.rs#L341) covering more advanced scenarios.
 

--- a/docs/06_devs/04_xchain.md
+++ b/docs/06_devs/04_xchain.md
@@ -132,16 +132,16 @@ Open a new issue in [Intergalactic asset metadata repository](https://github.com
 To add your tokens to our [Cross-chain](https://app.hydration.net/cross-chain) page, it is necessary to open a pull request to the [sdk repository](https://github.com/galacticcouncil/sdk).
 
 1. **Fork the sdk repository**.
-2. **Extend xcm-cfg package**.
-    1. If necessary, add a [new chain](https://github.com/galacticcouncil/sdk/blob/master/packages/xcm-cfg/src/chains/)
-    2. Add new [assets](https://github.com/galacticcouncil/sdk/blob/master/packages/xcm-cfg/src/assets.ts)
-    3. Add new AssetRoute to both chain config files, [Hydration](https://github.com/galacticcouncil/sdk/blob/master/packages/xcm-cfg/src/configs/polkadot/hydration/index.ts) and [your chain's](https://github.com/galacticcouncil/sdk/tree/master/packages/xcm-cfg/src/configs/polkadot)
+2. **Extend xc-cfg package**.
+    1. If necessary, add a [new chain](https://github.com/galacticcouncil/sdk/blob/master/packages/xc-cfg/src/chains/)
+    2. Add new [assets](https://github.com/galacticcouncil/sdk/blob/master/packages/xc-cfg/src/assets.ts)
+    3. Add new AssetRoute to both chain config files, [Hydration](https://github.com/galacticcouncil/sdk/blob/master/packages/xc-cfg/src/configs/polkadot/hydration/index.ts) and [your chain's](https://github.com/galacticcouncil/sdk/tree/master/packages/xc-cfg/src/configs/polkadot)
 3. (Optional / Recommended) **Test your changes locally in developer console**.
     1. Build the project by following [README.md](https://github.com/galacticcouncil/sdk/blob/master/README.md)
-    2. Change current directory to `/examples/xcm-transfer/`
-    3. Adjust chains, asset, adresses and balance definitions in the [index file](https://github.com/galacticcouncil/sdk/blob/master/examples/xcm-transfer/src/index.ts)
+    2. Change current directory to `/examples/xc-transfer/`
+    3. Adjust chains, asset, adresses and balance definitions in the [index file](https://github.com/galacticcouncil/sdk/blob/master/examples/xc-transfer/src/index.ts)
     4. Test your changes by running `npm run dev` and check the developer console output in your browser, typically at `localhost:3000`
-    5. Add a minor bump for `@galacticcouncil/xcm-cfg` package by running `npm run changeset`
+    5. Add a minor bump for `@galacticcouncil/xc-cfg` package by running `npm run changeset`
 3. **Open a PR from your fork to the main repository** and wait until the workflow is approved. UI preview with your changes will be deployed and appear in the PR description.
 4. **Try sending each of the registered tokens back and forth** from one chain to the other, and verify the deposits were successful and balances configuration is correct.
 5. **Add a comment that configuration is ready to be merged.**

--- a/docs/06_devs/05_collators/01_collator_setup.md
+++ b/docs/06_devs/05_collators/01_collator_setup.md
@@ -32,10 +32,10 @@ su - hydra
 
 ## Download and configure the `hydradx` binary
 
-Pick a 12.x release, we are using `v12.1.0` from our assets repository:
+Pick the [latest release](https://github.com/galacticcouncil/hydration-node/releases/latest) from our assets repository (`v49.0.2` at time of writing — substitute the current tag):
 
 ```bash
-wget https://github.com/galacticcouncil/HydraDX-node/releases/download/v12.1.0/hydradx
+wget https://github.com/galacticcouncil/hydration-node/releases/download/v49.0.2/hydradx
 sudo mv hydradx /usr/local/bin
 sudo chmod +x /usr/local/bin/hydradx
 sudo chown hydra:hydra /usr/local/bin/hydradx
@@ -64,7 +64,6 @@ ExecStart=/usr/local/bin/hydradx \
     --base-path /var/lib/hydradx \
     --collator \
     -- \
-    --execution wasm \
     --telemetry-url "wss://telemetry.hydradx.io:9000/submit/ 0" \
     --base-path /var/lib/hydradx
     
@@ -111,7 +110,7 @@ journalctl -fu hydradx-collator
 In order to generate keys for your node, run the following command:
 
 ```bash
-curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_rotateKeys", "params":[]}' http://localhost:9933
+curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_rotateKeys", "params":[]}' http://localhost:9944
 ```
 
 Once done, you will have an output similar to:

--- a/docs/06_devs/05_collators/02_performance_benchmark.md
+++ b/docs/06_devs/05_collators/02_performance_benchmark.md
@@ -5,43 +5,25 @@ description: Test and optimize node performance
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-You can make sure that your machine satisfies the [required technical specifications](./collator_setup#technical-specifications) by running a performance benchmark. To do so, follow the steps below:
+You can make sure that your machine satisfies the [required technical specifications](./collator_setup#technical-specifications) by running the `hydradx` binary's built-in hardware benchmark. Build or download the binary first (see [Set up a Development Chain](../build_dev_chain) or the [latest release](https://github.com/galacticcouncil/hydration-node/releases/latest)), then run:
 
 ```bash
-# Fetch source of the latest stable release
-$ git clone https://github.com/galacticcouncil/HydraDX-node -b stable
-$ cd HydraDX-node/
-
-# Prepare for running the benchmark
-## Install Rust following https://rustup.rs
-$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-## Configure Rust
-$ ./scripts/init.sh
-$ rustup default nightly
-
-## Install additional libraries
-$ apt install python3-pip
-$ apt install clang
-
-# Run the benchmark
-$ ./scripts/check_performance.sh
+$ ./hydradx benchmark machine
 ```
 
-After the benchmark executes you should see an output similar to the following:
+This runs Substrate's standard reference-hardware check (CPU, memory, and disk read/write throughput) and prints a pass/fail score for each category against the reference spec, for example:
 
 ```
-         Pallet          |   Time comparison (µs)    |  diff* (µs)   |   diff* (%)    |            |   Rerun
-amm                      |     773.00 vs 680.00      |      93.00    |      12.03     |     OK     |
-exchange                 |     804.00 vs 720.00      |      84.00    |      10.44     |     OK     |
-transaction_multi_payment|     218.00 vs 198.00      |      20.00    |       9.17     |     OK     |
-
-Notes:
-- in the diff fields you can see the difference between the reference benchmark time and the benchmark time of your machine
-- if diff is positive for all three pallets, your machine covers the minimum requirements for running a Hydration node
-- if diff deviates by -10% or more for some of the pallets, your machine might not be suitable to run a node
++----------+----------------------------------------+----------------+----------------+--------+
+| Category | Function                                | Score          | Minimum        | Result |
++----------+----------------------------------------+----------------+----------------+--------+
+| CPU      | BLAKE2-256 hashing                      | 1234.56 MB/s   | 1000.00 MB/s   | Pass   |
+| Memory   | Copy                                     | 12345.67 MB/s  | 8000.00 MB/s   | Pass   |
+| Disk     | Random write                            | 234.56 MB/s    | 150.00 MB/s    | Pass   |
+| Disk     | Random write with latency guarantee     | 100 MB/s        | 80 MB/s        | Pass   |
++----------+----------------------------------------+----------------+----------------+--------+
 ```
 
-You can see the difference in the performance between your machine and the minimum required setup in the column **diff* (%)**. If all three values in this column are positive, your machine should be suitable to run a Hydration validator node. If any of the values is below *-10 %*, we do not recommend running a Hydration node.
+If any category shows `Fail`, your machine falls short of the reference hardware for that category — consider upgrading before running a production collator.
 
 Join us at Discord if you would like to discuss your benchmark results, our community is always happy to help.

--- a/docs/06_devs/06_evm.md
+++ b/docs/06_devs/06_evm.md
@@ -1,0 +1,123 @@
+---
+title: EVM Integration
+description: Integrate with Hydration's EVM - RPC endpoints, precompiles, contract deployment, and testing
+---
+
+Hydration's EVM compatibility is provided by `pallet_evm` + `pallet_ethereum` — a Moonbeam-maintained fork of [Frontier](https://github.com/paritytech/frontier) embedded directly in the Substrate runtime, not a separate parachain or sidechain. This means:
+
+- Standard Solidity tooling (Hardhat, Foundry) and EVM wallets (MetaMask) work against Hydration without a bridge or wrapped-chain layer.
+- EVM transactions and Substrate extrinsics settle in the same block, on the same state.
+- The EVM sits alongside Hydration's native pallets (Omnipool, money market, HOLLAR, etc.), and several of those pallets are exposed to EVM contracts via precompiles.
+
+## Networks & RPC {#networks-rpc}
+
+**Mainnet** — EVM chain ID `222222` (`0x3640e`). All endpoints below serve both Substrate WSS and Ethereum JSON-RPC (`eth_*`) on the same host — there is no separate EVM-only endpoint:
+
+| Provider | Endpoint |
+|---|---|
+| Dwellir (default) | `wss://hydration-rpc.n.dwellir.com` |
+| Rotko (SEA) | `wss://hydration.rotko.net` |
+| sin | `wss://subway.sin.hydration.cloud` |
+| coke | `wss://subway.coke.hydration.cloud` |
+| kril | `wss://rpc.kril.hydration.cloud` |
+| shellfish | `wss://subway.shellfish.hydration.cloud` |
+| catfish-1 | `wss://rpc-catfish-1.catfish.hydration.cloud` |
+| catfish-2 | `wss://rpc-catfish-2.catfish.hydration.cloud` |
+| catfish-3 | `wss://rpc-catfish-3.catfish.hydration.cloud` |
+| catfish-4 | `wss://rpc-catfish-4.catfish.hydration.cloud` |
+
+For `eth_*` JSON-RPC, use the same hostnames over `https://` (e.g. `https://hydration-rpc.n.dwellir.com`).
+
+**Test networks** — Hydration doesn't run a separate long-lived public testnet with independent state; instead, mainnet-forked "lark" nodes serve as the disposable test environment, regularly reset to current mainnet state:
+
+- `https://0.lark.hydration.cloud`
+- `https://1.lark.hydration.cloud`
+- `https://2.lark.hydration.cloud`
+- `https://3.lark.hydration.cloud`
+
+Same chain ID as mainnet (`222222`) — there is no chain-ID-based way to distinguish a lark fork from mainnet. State can be reset at any time; don't rely on persistent test data across sessions.
+
+**Wallet configuration (EIP-3085 `wallet_addEthereumChain`):**
+
+```json
+{
+  "chainId": "0x3640e",
+  "chainName": "Hydration",
+  "rpcUrls": ["https://hydration-rpc.n.dwellir.com"],
+  "nativeCurrency": { "name": "Wrapped Ether", "symbol": "WETH", "decimals": 18 }
+}
+```
+
+Note the EVM "native" gas currency is a WETH-wrapped asset (`WethCurrency`), not HDX — Hydration's dynamic multi-currency fee system can also accept other registered assets for gas, but WETH is the default/primary one.
+
+## JSON-RPC surface {#json-rpc-surface}
+
+**Supported:** `eth_*` (including filters and `eth_subscribe` pubsub), `net_*`, `web3_*`.
+
+**Not supported:** `debug_*`, `trace_*`, `txpool_*` — there is no `debug_traceTransaction` or mempool introspection.
+
+**Gas estimation:** `eth_estimateGas` had a known reliability issue for bounded Substrate accounts; this was fixed in a `hydration-node` runtime upgrade (April 2026). Standard `eth_estimateGas`-based flows (MetaMask, ethers/viem defaults) should work without needing a manual safety multiplier.
+
+## Precompiles {#precompiles}
+
+Registered in `HydraDXPrecompiles<R>`:
+
+| Address | Name | Purpose |
+|---|---|---|
+| `0x...0001`–`0x...0009` | Standard Ethereum precompiles | ECRecover, SHA256, RIPEMD160, Identity, Modexp, BN128Add, BN128Mul, BN128Pairing, Blake2F |
+| `0x...0401` | Dispatch | Executes a Substrate runtime call from EVM context — the general Substrate↔EVM bridge |
+| `0x...0806` | LockManager | Backs GIGAHDX's `LockableAToken.sol`; restricted caller |
+| `0x...080a` | CallPermit | EIP-712-style typed call permit (permit + relayer pattern) |
+| `0x...090a` | FlashLoanReceiver | ERC-3156-compatible flashloan callback; restricted to the configured flash-minter |
+| `0x00000000000000000000000000000001XXXXXXXX` | Per-asset ERC-20 | Every registered Hydration asset is exposed as a standard ERC-20 at this address (last 4 bytes = big-endian `AssetId`) — trade/transfer native Hydration assets from EVM contracts as if they were ordinary ERC-20 tokens |
+| `0x000001XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | Chainlink-style oracle | AggregatorV3-compatible interface backed by Hydration's on-chain EMA oracle |
+
+The EVM's execution target is **Osaka** (a superset of Shanghai/Cancun/Prague) — `PUSH0`, transient storage (`TSTORE`/`TLOAD`), and `MCOPY` are all supported.
+
+## Contract deployment {#contract-deployment}
+
+Standard Hardhat/Foundry deployment flows work against the mainnet RPC endpoints above (chain ID `222222`). Note: transactions must be **legacy (type-0)** — some deploy scripts explicitly pass `--legacy`/set `type: 0` for reliability.
+
+**Contract-deployer allowlist:** Hydration gates who may deploy new contracts via `pallet_evm_accounts`'s `ContractDeployer` allowlist. Adding an address requires an on-chain governance action (`add_contract_deployer`, via root or an OpenGov `GeneralAdmin`-track referendum) — this is not self-serve. If you're planning to deploy contracts on Hydration mainnet, reach out to the Hydration team ahead of time (e.g. via [Discord](https://discord.gg/hydration-net) or a [Subsquare](https://hydration.subsquare.io/posts/create) discussion thread) to get your deployer address whitelisted through governance.
+
+## Contract verification {#contract-verification}
+
+Hydration's block explorer is [hydration.subscan.io](https://hydration.subscan.io). It provides transaction/block lookup across both the Substrate and EVM sides of the chain, but does not offer Blockscout/Etherscan-style contract source verification.
+
+If you need verified-source publication for your contracts, contact the Hydration team directly — this is a known gap rather than a self-serve flow today.
+
+## Local mainnet-fork testing with Chopsticks {#chopsticks}
+
+For local development against a fork of Hydration mainnet state, use the **`@galacticcouncil/chopsticks`** fork — not vanilla `@acala-network/chopsticks`, which lacks Frontier `eth_*` RPC support.
+
+```bash
+npx @galacticcouncil/chopsticks@latest --config=hydradx
+```
+
+This serves both Substrate and `eth_*` JSON-RPC on the same port (default `ws://localhost:8000`), forked from current Hydration mainnet state. Instant block production is the default build-block mode.
+
+**Gotchas:**
+- `eth_feeHistory` and `eth_maxPriorityFeePerGas` are synthetic, derived from a static `eth_gasPrice` under a fork — don't rely on fee-history-based gas estimation in this environment.
+- Legacy (type-0) transactions only, same as mainnet.
+
+**Whitelisting a deployer address on your fork:** the mainnet governance process above doesn't apply here — on Chopsticks you control the chain state directly. `ContractDeployer` is a plain `StorageMap<EvmAddress, ()>`, so Chopsticks' `dev_setStorage` RPC can write the entry directly, bypassing governance entirely:
+
+```js
+import { ApiPromise, WsProvider } from "@polkadot/api";
+
+const api = await ApiPromise.create({ provider: new WsProvider("ws://localhost:8000") });
+const evmAddress = "0xYourAddress...";
+
+// Resolve the storage value's encoding dynamically rather than hardcoding it —
+// ContractDeployer's value type isn't a plain unit in this runtime's metadata.
+const valueTypeId = api.query.evmAccounts.contractDeployer.creator.meta.type.asMap.value.toNumber();
+const valueTypeName = api.registry.createLookupType(valueTypeId);
+let value = api.createType(valueTypeName, valueTypeName === "bool" ? true : undefined).toHex();
+if (value === "0x00") value = "0x01";
+
+const key = api.query.evmAccounts.contractDeployer.key(evmAddress);
+await api.rpc("dev_setStorage", [[key, value]]);
+
+// Verify:
+console.log((await api.query.evmAccounts.contractDeployer(evmAddress)).toHuman());
+```

--- a/docs/06_devs/06_evm.md
+++ b/docs/06_devs/06_evm.md
@@ -9,6 +9,17 @@ Hydration's EVM compatibility is provided by `pallet_evm` + `pallet_ethereum` �
 - EVM transactions and Substrate extrinsics settle in the same block, on the same state.
 - The EVM sits alongside Hydration's native pallets (Omnipool, money market, HOLLAR, etc.), and several of those pallets are exposed to EVM contracts via precompiles.
 
+## Account mapping (Substrate ↔ EVM) {#account-mapping}
+
+Hydration accounts live in two address spaces — 32-byte Substrate `AccountId`s and 20-byte EVM addresses — and the mapping between them (`pallet_evm_accounts`) is asymmetric.
+
+**Substrate → EVM (always available, no action needed):** every Substrate `AccountId` already has an implicit EVM address — simply its **first 20 bytes**. This is how a Substrate-signed extrinsic's identity shows up inside the EVM (e.g. as the caller for calls routed through the [Dispatch precompile](#precompiles)).
+
+**EVM → Substrate** has two cases:
+
+- **Unbound (default).** For a raw EVM address with no explicit link, Hydration derives a synthetic "truncated" `AccountId`: `"ETH\0"` (4 bytes) + the 20-byte EVM address + 8 zero bytes = 32 bytes. This is what holds balance and pays fees for a plain `eth_sendRawTransaction` from a fresh EOA — a one-way derivation, not tied to any real sr25519/ed25519 keypair.
+- **Bound, via `evmAccounts.bind_evm_address()`.** A user with an existing Substrate account can submit this extrinsic (no arguments — both sides are derived from the caller) to link the two. It stores the **last 12 bytes** of their real `AccountId` in on-chain storage, keyed by their EVM address (which, per the rule above, is just the first 20 bytes of that same `AccountId`). After binding, the runtime reconstructs their real account as `evm_address (20 bytes) + stored last 12 bytes` — so an existing Substrate account's HDX/asset balances become directly usable from the EVM side, instead of a separate synthetic shadow account. Binding is optional; most raw EOA-signed EVM transactions never bind anything and just use the synthetic form.
+
 ## Networks & RPC {#networks-rpc}
 
 **Mainnet** — EVM chain ID `222222` (`0x3640e`). All endpoints below serve both Substrate WSS and Ethereum JSON-RPC (`eth_*`) on the same host — there is no separate EVM-only endpoint:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,5 @@
-const math = require('remark-math');
-const katex = require('rehype-katex');
+const math = require('remark-math').default;
+const katex = require('rehype-katex').default;
 
 module.exports = {
   title: "Hydration Docs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,7 +2464,7 @@
     "@docusaurus/theme-search-algolia" "3.1.1"
     "@docusaurus/types" "3.1.1"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -3977,9 +3977,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001280, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001627"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001627.tgz"
-  integrity sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==
+  version "1.0.30001803"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz"
+  integrity sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -8469,6 +8469,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-router-config@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
## Summary
- **New:** `docs/06_devs/06_evm.md` — EVM integration guide (RPC endpoints, JSON-RPC surface, precompiles, contract deployment & deployer whitelisting, verification status, Chopsticks fork testing + deployer-whitelisting recipe)
- **Fixed** several stale/broken references found while reviewing the dev section:
  - `HydraDX-node` → `hydration-node` (repo was renamed; old links still 301-redirect but updated to canonical)
  - `git clone -b stable` → `-b master` — `stable` is **9766 commits behind master**, effectively an abandoned branch
  - Dead links: substack "New Deal reward scheme" post (404), Acala Runtime Developer Academy (404), `substrate.dev` deep link (now redirects to the `docs.polkadot.com` homepage, not the actual guide) — replaced with `docs.polkadot.com`
  - SDK package rename: `xcm-cfg` → `xc-cfg`, `examples/xcm-transfer` → `examples/xc-transfer` (confirmed against current `sdk` repo structure)
  - Collator setup: binary pinned to `v12.1.0` (current latest is `v49.0.2`, ~37 releases behind) — now points at the releases page; `--execution wasm` CLI flag no longer exists in the current node and was removed; RPC port `9933` (legacy split HTTP RPC) → unified `9944`
  - Performance benchmark: `scripts/check_performance.sh` no longer exists in `hydration-node` (only `scripts/benchmarking.sh`, which is pallet weight-benchmarking, not a hardware-spec checker) — replaced the whole workflow with the binary's built-in `benchmark machine` subcommand, which does exist and serves the same purpose

## Test plan
- [ ] Build the site locally (`yarn build`) to confirm the new MDX page renders correctly
- [ ] Spot-check the RPC endpoints and precompile addresses in the new EVM page against current `hydration-node` source
- [ ] Confirm `hydradx benchmark machine` output format matches what's now documented